### PR TITLE
chore: update GitHub Actions to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
           - {os: macos-latest, python: "3.12", lock_os: macos, py_tag: py312}
     steps:
       - name: Check out source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -54,9 +54,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -93,9 +93,9 @@ jobs:
           - {os: macos-latest, lock_os: macos}
     steps:
       - name: Check out source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` to the verified `v7.0.1` commit SHA in all three jobs.
- Pin `actions/setup-python` to the verified `v7.0.0` commit SHA in all three jobs.
- Keep the existing OS/Python matrix, cache inputs, permissions, and job behavior unchanged.

## Why a replacement PR

Dependabot PRs #1 and #2 were created from the initial `6712007` baseline and are six main-branch commits behind. Their recorded failures came from requirement-lock metadata and cross-platform validation defects that were fixed later; they do not establish a regression in the v7 actions. This branch applies both updates cleanly to current `main`.

## Local validation

- `python -m unittest discover -s tests -q`: 243 tests completed; 242 passed and one Windows-inapplicable POSIX mode-bit test skipped.
- Ruff: passed.
- 20 hash-locked requirement files: verified.
- Public-tree audit: zero findings.
- Action pins: exactly three checkout and three setup-python references; old SHAs absent.
- `git diff --check`: passed.

## Boundary

This changes CI action runtimes only. It does not change application runtime code, dependencies, release assets, tags, or repository settings. Existing Dependabot PRs remain open pending review. GitHub-hosted cross-platform execution must be established by this PR's own checks.