### PR TITLE
chore: refresh build dependencies and lock metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   - package-ecosystem: pip
     directory: "/"
+    # requirements-lock/ is generated together with its integrity manifest.
+    # Direct edits bypass that contract and are rejected by CI.
+    exclude-paths:
+      - "requirements-lock/**"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 - macOS 构建包验收脚本升级为 r9：测试服务使用动态回环端口并持久化最近收尾状态；证据封装前等待日志写入完成，排除 AppleDouble 资源文件，并记录测试服务与 VSG 的独立退出证明。
 - Windows 打包改用独立暂存目录；若同版本旧解压目录仍在运行，构建会保留其进程与数据库，只生成并验证新的便携 ZIP，不再为覆盖目录而要求强制退出旧实例。
 
+### Release engineering
+
+- 将 Windows、macOS 与 Linux 的 PyInstaller 构建依赖统一更新到 `6.22.2`，并使用公开 PyPI 重新生成全部 20 份 Wheel-only SHA-256 锁及完整性 manifest。
+- 审计工具锁同步更新 Pygments `2.21.0`、charset-normalizer `3.5.1`、idna `3.19` 与 stevedore `5.9.1`；Dependabot 不再直接修改 `requirements-lock/` 生成目录，依赖 PR 必须通过项目生成器刷新完整锁集。
+
 ### Boundary
 
 - 所有桌面集成默认关闭；本轮构建和测试不会修改维护者机器的开机启动项或注册全局快捷键。0.8.5.2 r8 已在 macOS 13.7.8 x86_64 AMD/VMware 客体完成一次自动原生预览验收，但人工界面证据不完整，且 r9 证据脚本仍待该目标环境复验；它不能替代实体 Intel Mac、Apple Silicon、Linux 或硬件传感器验收。macOS/Linux 托盘与完整原生矩阵仍属于 0.8.6 P2-B。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,17 @@ python scripts/Audit-Public-Tree.py --root .
 
 Windows 使用 `.venv\Scripts\python.exe`，macOS/Linux 使用 `.venv/bin/python3`。
 
+## 依赖更新与锁文件
+
+`requirements-lock/` 由 `scripts/Requirement-Locks.py` 连同完整性清单统一生成，禁止手工修改单个锁文件。Dependabot 会检查根目录中的直接依赖声明，但会忽略生成目录；收到依赖更新后，维护者必须从仓库根目录执行：
+
+```text
+python scripts/Requirement-Locks.py --generate
+python scripts/Requirement-Locks.py --verify
+```
+
+生成过程仅使用公开 PyPI、只接受 Wheel 和 SHA-256，并会刷新所有目标平台/Python 版本的锁文件及 `requirements-lock/manifest.json`。PR 必须同时提交源依赖、受影响的全部锁文件和 manifest，随后运行完整测试与对应平台打包验证。
+
 ## 提交要求
 
 - 一个改动解决一个明确问题，并补充失败前、修复后都能解释的测试。

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,7 +18,7 @@ The precise Python version and complete composite license are collected from the
 
 Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola. Redistribution and use in source and binary forms, with or without modification, are permitted under the conditions stated in the upstream BSD 3-Clause license. The portable build contains the complete text copied from the installed `psutil` distribution.
 
-## PyInstaller 6.22.0
+## PyInstaller 6.22.2
 
 - Project: <https://github.com/pyinstaller/pyinstaller>
 - License: GPL-2.0-or-later with a special exception for distributing bundled applications

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -2,6 +2,14 @@
 
 本文保留 Vibe Service Guardian 0.4.0–0.8.5.1 的既有验证证据，并追加 0.8.5.2 P1 日常工作流及受限 macOS x86_64 VMware 预览的可复核结果。以下 0.8.5.2 验证轮次执行时没有提交、推送、发布 Release 或提交 OpenAI 申请；后续 Git 合并不改变这些目标环境证据的范围或结论。
 
+## 0.8.5.2 依赖与 CI 维护验收（2026-08-22）
+
+- Windows、macOS 与 Linux 的直接构建依赖统一从 PyInstaller `6.22.0` 更新到 `6.22.2`。项目生成器从公开 PyPI 重新解析全部 20 个 Wheel-only SHA-256 锁目标并刷新 `requirements-lock/manifest.json`；连续第二次生成的所有文件哈希完全一致，随后离线完整性验证通过。
+- 审计工具传递依赖同步更新 Pygments `2.20.0→2.21.0`、charset-normalizer `3.5.0→3.5.1`、idna `3.18→3.19` 与 stevedore `5.9.0→5.9.1`。Ruff、Bandit 中/高风险门禁、四组 `pip-audit`、`pip check`、Python 字节码编译、两个前端 JavaScript 语法检查、YAML 解析、公开树审计和 `git diff --check` 均通过；该漏洞结论只代表 2026-08-22 当次数据库。
+- 完整 unittest 共 243 项：242 通过，1 项因 Windows 不适用 POSIX mode-bit 断言而跳过。Windows 11 / CPython 3.12.10 使用 PyInstaller `6.22.2` 生成未签名 EXE，并通过仅回环监听、Host/Origin/错误令牌拒绝、CSP、离线模型规划、空历史门禁和优雅关停 smoke；ZIP 共 47 个条目、无运行数据，许可证清单和 SPDX 2.3 SBOM 中的 PyInstaller 版本为 `6.22.2`。
+- macOS r9 ZIP/tar.gz 与 Linux ZIP 源码构建包通过单根目录、路径安全、运行数据排除、公开树和 SHA-256 验证；macOS tar 保留必需脚本可执行位。它们由 Windows 主机生成，只证明构建包完整性，不能替代 macOS/Linux 目标系统的原生二进制、桌面或硬件验收。
+- Dependabot 的 pip 配置排除 `requirements-lock/**`，避免机器人单独修改生成锁而绕过 manifest；直接依赖更新仍需维护者运行 `scripts/Requirement-Locks.py --generate` 并提交完整锁集。本轮没有推送、合并、关闭现有 Dependabot PR、创建 Release 或更改远程仓库设置。
+
 ## 0.8.5.2 P1 日常工作流验收（2026-08-16）
 
 - 首页固定展示实际运行版本、PID、回环端口与运行时长，并提供首次使用检查、提醒中心、项目安全清理和安全退出入口。跨版本重复启动只记录请求/运行版本、PID、端口、时间和动作，不记录数据目录或控制令牌。

--- a/requirements-build-linux.txt
+++ b/requirements-build-linux.txt
@@ -1,5 +1,5 @@
 pip==26.2.1
-pyinstaller==6.22.0
+pyinstaller==6.22.2
 altgraph==0.17.5
 packaging==26.3
 pyinstaller-hooks-contrib==2026.6

--- a/requirements-build-macos.txt
+++ b/requirements-build-macos.txt
@@ -1,5 +1,5 @@
 pip==26.2.1
-pyinstaller==6.22.0
+pyinstaller==6.22.2
 altgraph==0.17.5
 macholib==1.16.4
 packaging==26.3

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,5 @@
 pip==26.2.1
-pyinstaller==6.22.0
+pyinstaller==6.22.2
 altgraph==0.17.5
 packaging==26.3
 pefile==2024.8.26

--- a/requirements-lock/audit-linux-py312.txt
+++ b/requirements-lock/audit-linux-py312.txt
@@ -16,9 +16,9 @@ cachecontrol==0.14.4 \
 certifi==2026.7.22 \
     --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775
 
-charset-normalizer==3.5.0 \
-    --hash=sha256:14f6904a3cf870abf044df3a8c4924ac6c8ef77e9896586fd37e73ae96cff2af \
-    --hash=sha256:608553f476fca509537e804c4a71f5eb166ce63b75141f89c2c686ce1aa36956
+charset-normalizer==3.5.1 \
+    --hash=sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa \
+    --hash=sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08
 
 colorama==0.4.6 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -32,8 +32,8 @@ defusedxml==0.7.1 \
 filelock==3.32.3 \
     --hash=sha256:7f0ca4bcc0e181c60dbbd8aa9ab5b120ebb99e4e064e83636340056f833a1f09
 
-idna==3.18 \
-    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+idna==3.19 \
+    --hash=sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4
 
 license-expression==30.4.4 \
     --hash=sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4
@@ -72,8 +72,8 @@ platformdirs==4.11.3 \
 py-serializable==2.1.0 \
     --hash=sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304
 
-pygments==2.20.0 \
-    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+pygments==2.21.0 \
+    --hash=sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9
 
 pyparsing==3.3.2 \
     --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d
@@ -95,8 +95,8 @@ ruff==0.16.3 \
 sortedcontainers==2.4.0 \
     --hash=sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
 
-stevedore==5.9.0 \
-    --hash=sha256:e520945d4c257700eddc1eb1d79df04b2ea578eef185e0e3fa5b442fc848d3f7
+stevedore==5.9.1 \
+    --hash=sha256:5c8ff3a9f336cc1a06ac0f597bc79d11a2f950bfd32e290ca56b5a301fafafbf
 
 tomli==2.4.1 \
     --hash=sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5 \

--- a/requirements-lock/build-linux-py310.txt
+++ b/requirements-lock/build-linux-py310.txt
@@ -17,9 +17,9 @@ psutil==7.2.2 \
     --hash=sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9 \
     --hash=sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e
 
-pyinstaller==6.22.0 \
-    --hash=sha256:b07ac9fd1d661ae4d0af6752c3941e4e5576a16cfe7e2d6504a32d57e17d0acc \
-    --hash=sha256:f92f78a9c463b884d57f90c7459c0cb263ccd26a499356bbfac7a5f41fd5b93f
+pyinstaller==6.22.2 \
+    --hash=sha256:9622686ecc5d5fa492fe6cde29d47df9dd41138cff8177be9f901ca3260f2096 \
+    --hash=sha256:f5ccb847451df4207bce18bf53a57b124c9bb4e7e4bad08c5ecc627bcf00b28c
 
 pyinstaller-hooks-contrib==2026.6 \
     --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3

--- a/requirements-lock/build-linux-py311.txt
+++ b/requirements-lock/build-linux-py311.txt
@@ -17,9 +17,9 @@ psutil==7.2.2 \
     --hash=sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9 \
     --hash=sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e
 
-pyinstaller==6.22.0 \
-    --hash=sha256:b07ac9fd1d661ae4d0af6752c3941e4e5576a16cfe7e2d6504a32d57e17d0acc \
-    --hash=sha256:f92f78a9c463b884d57f90c7459c0cb263ccd26a499356bbfac7a5f41fd5b93f
+pyinstaller==6.22.2 \
+    --hash=sha256:9622686ecc5d5fa492fe6cde29d47df9dd41138cff8177be9f901ca3260f2096 \
+    --hash=sha256:f5ccb847451df4207bce18bf53a57b124c9bb4e7e4bad08c5ecc627bcf00b28c
 
 pyinstaller-hooks-contrib==2026.6 \
     --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3

--- a/requirements-lock/build-linux-py312.txt
+++ b/requirements-lock/build-linux-py312.txt
@@ -17,9 +17,9 @@ psutil==7.2.2 \
     --hash=sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9 \
     --hash=sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e
 
-pyinstaller==6.22.0 \
-    --hash=sha256:b07ac9fd1d661ae4d0af6752c3941e4e5576a16cfe7e2d6504a32d57e17d0acc \
-    --hash=sha256:f92f78a9c463b884d57f90c7459c0cb263ccd26a499356bbfac7a5f41fd5b93f
+pyinstaller==6.22.2 \
+    --hash=sha256:9622686ecc5d5fa492fe6cde29d47df9dd41138cff8177be9f901ca3260f2096 \
+    --hash=sha256:f5ccb847451df4207bce18bf53a57b124c9bb4e7e4bad08c5ecc627bcf00b28c
 
 pyinstaller-hooks-contrib==2026.6 \
     --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3

--- a/requirements-lock/build-macos-py310.txt
+++ b/requirements-lock/build-macos-py310.txt
@@ -20,8 +20,8 @@ psutil==7.2.2 \
     --hash=sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979 \
     --hash=sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486
 
-pyinstaller==6.22.0 \
-    --hash=sha256:d7c7c5b149f7f9b37585b37e2376f774038b6a5633ba34db0de2698f75391e13
+pyinstaller==6.22.2 \
+    --hash=sha256:ebd1b1ca932d7cf25d7366ce691aaf79a5ff9425811ed7328b5116e4471b6d6d
 
 pyinstaller-hooks-contrib==2026.6 \
     --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3

--- a/requirements-lock/build-macos-py311.txt
+++ b/requirements-lock/build-macos-py311.txt
@@ -20,8 +20,8 @@ psutil==7.2.2 \
     --hash=sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979 \
     --hash=sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486
 
-pyinstaller==6.22.0 \
-    --hash=sha256:d7c7c5b149f7f9b37585b37e2376f774038b6a5633ba34db0de2698f75391e13
+pyinstaller==6.22.2 \
+    --hash=sha256:ebd1b1ca932d7cf25d7366ce691aaf79a5ff9425811ed7328b5116e4471b6d6d
 
 pyinstaller-hooks-contrib==2026.6 \
     --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3

--- a/requirements-lock/build-macos-py312.txt
+++ b/requirements-lock/build-macos-py312.txt
@@ -20,8 +20,8 @@ psutil==7.2.2 \
     --hash=sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979 \
     --hash=sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486
 
-pyinstaller==6.22.0 \
-    --hash=sha256:d7c7c5b149f7f9b37585b37e2376f774038b6a5633ba34db0de2698f75391e13
+pyinstaller==6.22.2 \
+    --hash=sha256:ebd1b1ca932d7cf25d7366ce691aaf79a5ff9425811ed7328b5116e4471b6d6d
 
 pyinstaller-hooks-contrib==2026.6 \
     --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3

--- a/requirements-lock/build-windows-py310.txt
+++ b/requirements-lock/build-windows-py310.txt
@@ -19,8 +19,8 @@ pip==26.2.1 \
 psutil==7.2.2 \
     --hash=sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988
 
-pyinstaller==6.22.0 \
-    --hash=sha256:6e5f3656de100954bf5db25536c43e097e46d482843a96d03a0852bf266e4853
+pyinstaller==6.22.2 \
+    --hash=sha256:9b990fa6bbe143572f06644a984ad0d7aa2e2ccc6929d4916031343a5888e9a7
 
 pyinstaller-hooks-contrib==2026.6 \
     --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3

--- a/requirements-lock/build-windows-py311.txt
+++ b/requirements-lock/build-windows-py311.txt
@@ -19,8 +19,8 @@ pip==26.2.1 \
 psutil==7.2.2 \
     --hash=sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988
 
-pyinstaller==6.22.0 \
-    --hash=sha256:6e5f3656de100954bf5db25536c43e097e46d482843a96d03a0852bf266e4853
+pyinstaller==6.22.2 \
+    --hash=sha256:9b990fa6bbe143572f06644a984ad0d7aa2e2ccc6929d4916031343a5888e9a7
 
 pyinstaller-hooks-contrib==2026.6 \
     --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3

--- a/requirements-lock/build-windows-py312.txt
+++ b/requirements-lock/build-windows-py312.txt
@@ -19,8 +19,8 @@ pip==26.2.1 \
 psutil==7.2.2 \
     --hash=sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988
 
-pyinstaller==6.22.0 \
-    --hash=sha256:6e5f3656de100954bf5db25536c43e097e46d482843a96d03a0852bf266e4853
+pyinstaller==6.22.2 \
+    --hash=sha256:9b990fa6bbe143572f06644a984ad0d7aa2e2ccc6929d4916031343a5888e9a7
 
 pyinstaller-hooks-contrib==2026.6 \
     --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3

--- a/requirements-lock/manifest.json
+++ b/requirements-lock/manifest.json
@@ -1,17 +1,17 @@
 {
   "generator": "scripts/Requirement-Locks.py",
   "lock_hashes": {
-    "audit-linux-py312.txt": "b300c23a1a482bb067e6bae719694280966762e274bd7ef3781ae754471ec1c1",
+    "audit-linux-py312.txt": "93e123f2ff4514090dc4b930e7921a9e304fa18608fd0030a025489799019d06",
     "bootstrap-py3.txt": "f61fa9a257ee614c9afb74d34f05fda610624233a672cbe34d99d3a5cdcd6e2f",
-    "build-linux-py310.txt": "70273f1d341b4a652f52503bcff41bc93139309c3ad30c7504ea1164b090dfc9",
-    "build-linux-py311.txt": "2ea8e8ca30b1f5e4a24ea42c2313d8a44f194946b718cb721f6f9994ad8f23a2",
-    "build-linux-py312.txt": "da171171d5b4ddc96f9fd6be7d59e7005c3344d9afdd56e202104fc56a311048",
-    "build-macos-py310.txt": "e668f6e6ea5c5a1830c9a8a4d8a913f72301bfc7b8530f4d6cad812464255c8b",
-    "build-macos-py311.txt": "6ec784b3c7910ed49a1fb36d39d2815d3ae7de56be5d93e4ad48d019a32ae77a",
-    "build-macos-py312.txt": "2b3be602aabd5c46513b9ec1b9c14918e9e6e9ce9ad038e32c83cc0b4b954a5b",
-    "build-windows-py310.txt": "27cb8ac90acb3ce551d5157051a10891ad3f06f25c1d8b56dbc26edd76997f75",
-    "build-windows-py311.txt": "229bf0d9a7d687ecb45e47817cb9dabbf80228ff8dce36f103e90877797efe8d",
-    "build-windows-py312.txt": "1f3555d539f907a07ca43e620f8f33b58529b3f12e349895b2dda3830d88b157",
+    "build-linux-py310.txt": "b093d12cfc097f7c99f2842cc1323db1ffb0624095f841e69ded6dfa5651e7ec",
+    "build-linux-py311.txt": "5cf604c68c57714bfb499e090ac5c9f27b06313543c678be256c7f1d6f31279b",
+    "build-linux-py312.txt": "cb100a95326d5c0e169346d6905511bb2f2709a9fe54829714386c5325210e0f",
+    "build-macos-py310.txt": "daa18f2f7930fc69b3f7928c1faa9d1356580d2873611e19dce98f841cb7e4d1",
+    "build-macos-py311.txt": "3aa77e91d4d3193e4d4b3a60d87766a0f24fcf5284c83f3df7add1db786e71e7",
+    "build-macos-py312.txt": "84863fe6d11845360251a69f38adac6faf967aa701f083ba50cf033535594558",
+    "build-windows-py310.txt": "728542d75ae8c7fba7de7da8f1f56aaa0bfabdc21a8655ddee3864a8c82d22d1",
+    "build-windows-py311.txt": "b9e4955236ddef57e6355a2e75783929f11628340cdd25ef5f1ef3ccf0c0cebc",
+    "build-windows-py312.txt": "8d71ca382ef49d42f16907ca71c052c9bece938ffeccdd3a848176a00dfd0d40",
     "runtime-linux-py310.txt": "9eac421c6ee63d5dd4ed8e00e93ab33560d7e629a15c98c8b5c6355da8f8c601",
     "runtime-linux-py311.txt": "e0ec61d96b906972efbf8ba6848a4f93fc6357d019d06c2434ea780a14ae48d8",
     "runtime-linux-py312.txt": "3e53e896be60e10a27b1bc93c1cc84054f46ccfd3e1410c776c81f1adb07edb9",
@@ -32,9 +32,9 @@
   "source_hashes": {
     "requirements-audit.txt": "6949e8f7c04b30d35680b64ea85d3651283107daf0b1b4b2f26096c3f883ddab",
     "requirements-bootstrap.txt": "ccf0c6f90dc1328272aaeaff8a35b03f39a25f1889194a913f7648f387593b04",
-    "requirements-build-linux.txt": "dbef6703d1a65f926432762e6978b716973e3e3ff4caea902e6b9f7339964eac",
-    "requirements-build-macos.txt": "310976e1c3b08acfa89cf4698517154cdc8f8b685ef4b666a0a347f1951613ff",
-    "requirements-build.txt": "426d97839544a7e52c918c9fd7738de67a82db7e3c6a1b75fb6762566968b8f7",
+    "requirements-build-linux.txt": "eea2528fe8812672f1d7042ebfbc9c29a53f331d23ca1116d2685c38423a12d5",
+    "requirements-build-macos.txt": "fa38dfdfb6eaee3416d0414e3f79b91c1ad3b70f0a9760fbfc162b73ac022338",
+    "requirements-build.txt": "f60a38641195e22fbec352a550a15a372a0668a113f55f90db8671c5c31c517a",
     "requirements.txt": "ce972e5602f1badf47b56ce597ebf4a3cbc516ca6c8979c95ee75c067d275840"
   }
 }


### PR DESCRIPTION
## Summary

- Update the Windows, macOS, and Linux PyInstaller build pin from `6.22.0` to `6.22.2`.
- Regenerate all 20 wheel-only SHA-256 locks and `requirements-lock/manifest.json` from public PyPI.
- Refresh audit-tool transitive pins: Pygments `2.21.0`, charset-normalizer `3.5.1`, idna `3.19`, and stevedore `5.9.1`.
- Exclude generated `requirements-lock/**` files from direct Dependabot edits and document the required full-lock refresh workflow.
- Align the changelog, validation evidence, and third-party notice with the exact build environment.

## Root cause addressed

PR #7 changed source requirements and generated locks without refreshing manifest source hashes. PRs #8-#10 edited the generated audit lock without refreshing its recorded digest. CI correctly rejected both patterns. This branch regenerates the complete lock set through the repository's own generator. Existing Dependabot PRs remain open pending review.

## Validation

- Lock generation repeated twice with identical file hashes; all 20 targets verified.
- `python -m unittest discover -s tests -q`: 243 tests completed; 242 passed and one Windows-inapplicable POSIX mode-bit test skipped.
- Ruff and Bandit medium/high gate: passed.
- `pip-audit` for runtime plus Windows/macOS/Linux build requirements: no known vulnerabilities at test time.
- `pip check`, Python compileall, JavaScript syntax checks, YAML parsing, public-tree audit, and `git diff --check`: passed.
- Windows PyInstaller 6.22.2 EXE: native loopback/security/graceful-shutdown smoke passed; 47-entry ZIP, licenses, and SPDX SBOM validated.
- macOS r9 ZIP/tar.gz and Linux ZIP source build kits: archive integrity and runtime-data exclusion passed on Windows. Native target-platform execution remains unverified.

## Release boundary

No runtime feature behavior changes. Release assets must be rebuilt from final `main` after this PR and the CI-actions PR are merged. This PR does not create a tag, GitHub Release, or release upload.