### PR TITLE
docs: document private vulnerability reporting

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,7 @@ This file uses only the maintainer's chosen public GitHub identity. It does not 
 |---|---|
 | Primary/core maintainer | [`keith-yan`](https://github.com/keith-yan) |
 | Release authority | `keith-yan` only |
-| Security contact | Not yet public; use GitHub Private Vulnerability Reporting after it is enabled |
+| Security contact | [GitHub Private Vulnerability Reporting](https://github.com/keith-yan/vibe-service-guardian/security/advisories/new) |
 | Backup maintainer | None |
 | Bus factor | 1 |
 
@@ -30,7 +30,7 @@ A contributor may be invited as a maintainer only after sustained, reviewable co
 ## Public repository follow-up
 
 - [x] Add the maintainer’s chosen public name/handle and GitHub profile URL.
-- [ ] Add a non-secret public contact or enable GitHub Private Vulnerability Reporting.
+- [x] Enable GitHub Private Vulnerability Reporting as the non-secret public security channel.
 - [x] Record that the personal account `keith-yan` owns releases and security advisories.
 - [ ] Identify a backup maintainer or explicitly accept the bus-factor-one risk.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -118,6 +118,6 @@ POSIX 数据目录尽力使用 `0700`，配置、数据库、日志和运行实�
 
 ## 报告漏洞
 
-公开仓库启用 GitHub Private Vulnerability Reporting 后，请优先使用该渠道，并提供最小复现、受影响版本、平台和已脱敏证据。不要在公开 Issue 中披露可利用细节、密钥、本机数据库或会话文件。
+仓库已启用 GitHub Private Vulnerability Reporting。疑似安全漏洞请通过[私密报告入口](https://github.com/keith-yan/vibe-service-guardian/security/advisories/new)提交，并提供最小复现、受影响版本、平台、影响说明和已脱敏证据。
 
-仓库尚未启用私密报告时，可以创建不含漏洞细节的公开 Issue，请求维护者提供私密联系方式。维护者在正式公开仓库前仍需补充可验证的安全联系人；当前文件不能代替该人工决定。
+不要在公开 Issue、Discussion 或 PR 中披露可利用细节、密钥、本机数据库、原始日志、绝对路径或 Agent 会话文件。无法访问私密入口时，只能公开说明“需要私密安全联系方式”，不得附带漏洞细节；仓库目前不公布维护者私人邮箱，也不承诺固定响应时限。

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -17,4 +17,6 @@
 - 对 Agent 未公开内部格式的持续兼容；
 - 未经实机验证的平台组合。
 
-安全漏洞请遵循 [SECURITY.md](SECURITY.md)，不要公开利用细节。
+## 安全漏洞
+
+不要通过公开 Issue 报告安全漏洞。请先阅读 [SECURITY.md](SECURITY.md)，再使用 [GitHub Private Vulnerability Reporting](https://github.com/keith-yan/vibe-service-guardian/security/advisories/new) 私密提交；不得附带未脱敏日志、数据库、路径、账号信息或凭据。

--- a/docs/PUBLIC-RELEASE-CHECKLIST.md
+++ b/docs/PUBLIC-RELEASE-CHECKLIST.md
@@ -9,8 +9,9 @@
 - [ ] 运行全部单元测试与依赖漏洞审计。
 - [ ] 在 Windows 10、Windows 11、Apple Silicon macOS、Intel macOS、Ubuntu/Linux x86_64 与 aarch64 图形桌面分别记录真实验收；无法获得的组合明确标为未验证。
 - [ ] 在真实 Hermes 与 OpenCode 中验证进程、项目、显式恢复会话和无目录元数据的降级行为。
-- [ ] 由维护者选择 GitHub 用户名/组织、仓库名、公开安全联系方式和维护策略。
-- [ ] 在 `MAINTAINERS.md` 填写与公开 GitHub 身份一致的核心维护者信息；复核 `GOVERNANCE.md` 与 `ROADMAP.md`。
+- [x] 由维护者选择 GitHub 用户名、公开仓库、维护策略和非秘密安全渠道；仓库使用 `keith-yan` 身份及 GitHub Private Vulnerability Reporting。
+- [x] 在 `MAINTAINERS.md` 填写与公开 GitHub 身份一致的核心维护者信息；已复核 `GOVERNANCE.md` 与 `ROADMAP.md`。
+- [x] 启用 GitHub Private Vulnerability Reporting，并确认 `SECURITY.md`、`SUPPORT.md` 与维护者清单指向同一私密入口。
 - [ ] 复核 `IMPACT.md` 与证据登记表：目标不得写成成就，本机报告不得写成独立采用；没有真实案例时保持“缺失”。
 - [ ] 初始化 Git 后检查首个提交内容；`release/`、`data/`、`.venv/`、`build/`、`dist/` 不应进入历史。
 - [ ] 推送后确认 CI 全绿，再创建无身份签名的预发布；为每个资产提供 SHA-256 与生成的 SBOM。


### PR DESCRIPTION
## Summary

- Document the repository's enabled GitHub Private Vulnerability Reporting channel in `SECURITY.md`.
- Replace the placeholder security-contact state in `MAINTAINERS.md` with the private reporting entry point.
- Route vulnerability reports away from public Issues in `SUPPORT.md`.
- Mark the repository-identity and private-reporting items complete in the public release checklist.

## Repository settings already verified

- GitHub Private Vulnerability Reporting is enabled.
- Fifteen repository topics are configured for vibe coding, developer tools, local AI, service/process/port monitoring, coding agents, supported operating systems, and privacy-first operation.
- The maintainer profile bio and repository website are public.

## Local validation

- `python -m unittest discover -s tests -q`: 243 tests completed; 242 passed and one Windows-inapplicable POSIX mode-bit test skipped.
- Ruff: passed.
- Bandit medium/high gate: passed.
- 20 hash-locked requirement files: verified.
- Public-tree audit: zero findings.
- Markdown relative links and `git diff --check`: passed.

## Boundary

This PR changes four documentation files only. It does not change runtime behavior, dependencies, release assets, repository permissions, tags, or Releases. Existing local release artifacts must be rebuilt from final `main` after this documentation change is merged.