### PR TITLE
docs: record post-release evidence

### DIFF
--- a/IMPACT.md
+++ b/IMPACT.md
@@ -1,6 +1,6 @@
 # Project impact and evidence / 项目影响与证据
 
-> Status: newly public repository, unreleased Alpha. This document separates verified engineering evidence, local self-reported outcomes, and independent public adoption. Repository existence is verified; independent adoption does not exist yet.
+> Status: newly public repository with one published unsigned Alpha prerelease. This document separates verified engineering evidence, local self-reported outcomes, public attention, and independent adoption. Repository/release existence and early GitHub interest are verified; independent adoption is not.
 
 ## Why this project exists / 为什么要做
 
@@ -26,7 +26,18 @@ Vibe Service Guardian turns those questions into a local evidence chain: detect 
 | E1 — Engineering verification | The implementation follows bounded control, privacy, migration, and protocol contracts | Available; see `docs/VALIDATION.md` and `docs/EVIDENCE-REGISTER.md` | Real-world adoption or user value |
 | E2 — Local self-reported outcomes | One VSG instance recorded whether flagged services were actually stale and whether stop/benchmark verification completed | Supported by the local impact report; no automatic upload | Independent user count or community impact |
 | E3 — Independent case evidence | A consenting external user describes the before/after result with reproducible, redacted evidence | Not yet available | Broad adoption unless the sample and method justify it |
-| E4 — Public ecosystem evidence | Public releases, unique contributors, issue/PR response, downloads, dependent projects, citations | Repository created at [`keith-yan/vibe-service-guardian`](https://github.com/keith-yan/vibe-service-guardian); no release or adoption evidence yet | Repository existence proves publication/control, not adoption or ecosystem importance |
+| E4 — Public ecosystem evidence | Public releases, unique contributors, issue/PR response, downloads, dependent projects, citations | Public repository plus [`v0.8.5.2-alpha.1`](https://github.com/keith-yan/vibe-service-guardian/releases/tag/v0.8.5.2-alpha.1); 112 Stars at the dated snapshot below | A release, Stars, maintainer PRs, or maintainer verification downloads do not prove users, installations, independent adoption, or ecosystem importance |
+
+## Public repository snapshot / 公开仓库快照（2026-08-23 00:43 UTC+8）
+
+This snapshot was read from GitHub after the first Alpha was published. It is a dated observation, not a live counter or a user estimate.
+
+- Public MIT repository created 2026-08-14; 112 Stars, 0 Forks, and 1 subscriber.
+- 11 commits on `main`; 14 pull requests in total, including 8 merged maintainer PRs and 6 closed-unmerged Dependabot PRs; 0 open PRs.
+- One contributor is reported: [`keith-yan`](https://github.com/keith-yan), the sole primary maintainer. This is not an independent contributor.
+- 0 public Issues and no public issue-response history.
+- One published checksum-backed prerelease, [`v0.8.5.2-alpha.1`](https://github.com/keith-yan/vibe-service-guardian/releases/tag/v0.8.5.2-alpha.1), with 6 uploaded files. GitHub reported 0 asset downloads at collection time.
+- Maintainer release verification included authenticated digest comparison and anonymous download checks. Any later download counter can include maintainer verification, bots, repeat downloads, and sidecar downloads, so it must not be translated into users or installations.
 
 ## Local impact report / 本机成效报告
 
@@ -59,16 +70,16 @@ The report deliberately states `external_adoption_verified: false`. Removing or 
 - SQLite migrations are versioned, backed up, transactionally applied, and corruption-tested.
 - Security, privacy, public-tree, dependency, and cross-platform build contracts are documented and automated where the current Windows host can validate them.
 - A local outcome/export path now exists so future users can produce redacted, reviewable evidence instead of anecdotal claims.
-- The public GitHub repository exists at [`keith-yan/vibe-service-guardian`](https://github.com/keith-yan/vibe-service-guardian); its initial publication is repository-control evidence only.
+- The public repository and first unsigned Alpha exist at [`keith-yan/vibe-service-guardian`](https://github.com/keith-yan/vibe-service-guardian) and [`v0.8.5.2-alpha.1`](https://github.com/keith-yan/vibe-service-guardian/releases/tag/v0.8.5.2-alpha.1). The release has 6 allowlisted assets, matching remote SHA-256 digests, a Windows SPDX SBOM, explicit platform limitations, and no Linux binary claim.
 
-This is maintenance and product-readiness evidence. It is not evidence of public popularity.
+This is maintenance, release-integrity, and early-interest evidence. It is not evidence of independent adoption or broad public use.
 
 ## Evidence still missing / 尚缺证据
 
-- At initial publication there is no public release, verified download/user evidence, dependent project, citation, or independent contributor; repository counters must not be interpreted as adoption without context.
+- No verified external user, installation, independently attributable download, dependent project, citation, or independent contributor. GitHub counters must not be interpreted as adoption without context.
 - No consented external case study or independently verified user outcome.
 - No native Apple Silicon, Intel macOS, Linux x86_64, or Linux arm64 acceptance result from this Windows workspace.
-- No public issue/PR response history or sustained release cadence.
+- No public issue-response history and only one prerelease; a sustained release/maintenance cadence is not yet established.
 
 ## How to add a real case / 如何补充真实案例
 

--- a/docs/EVIDENCE-REGISTER.md
+++ b/docs/EVIDENCE-REGISTER.md
@@ -13,13 +13,15 @@ This register prevents code verification from being misrepresented as user adopt
 | VSG-E007 | Native platform preview | macOS 13.7.8 x86_64 VMware guest can build the native package and pass automated native validation | [`case-studies/macos-vm-preview-0.8.5.2.md`](case-studies/macos-vm-preview-0.8.5.2.md) | Partial | AMD-hosted VM; manual UI evidence and r9 target rerun are incomplete; does not cover physical Intel Mac or Apple Silicon |
 | VSG-E008 | Native platform | Linux x86_64 and arm64 graphical acceptance | `LINUX-VALIDATION.md` | Missing | Must run on real target machines |
 | VSG-E009 | Independent outcome | External user case study with consent and redacted evidence | `docs/case-studies/` | Missing | Cannot be replaced by maintainer testing |
-| VSG-E010 | Public ecosystem | Public releases, contributors, issues/PRs, downloads, dependents, citations | [`keith-yan/vibe-service-guardian`](https://github.com/keith-yan/vibe-service-guardian) | Partial | Repository existence proves publication/control only; no release or adoption evidence yet |
+| VSG-E010 | Public ecosystem | Dated public counters and maintainer activity exist | [`keith-yan/vibe-service-guardian`](https://github.com/keith-yan/vibe-service-guardian), [`IMPACT.md`](../IMPACT.md) | Partial | 112 Stars, maintainer PRs, one maintainer contributor, and GitHub counters show attention/activity, not users, installations, independent adoption, or ecosystem importance |
 | VSG-E011 | Engineering | P1 project cleanup remains per-service, local alerts migrate safely, and optional Windows desktop integration defaults off | `tests/test_v0852_p1.py`, `docs/VALIDATION.md` | Available | Current Windows host and synthetic/local evidence; no long-term user or native macOS/Linux result |
+| VSG-E012 | Public release integrity | The first unsigned Alpha is published from the reviewed tag with 6 allowlisted assets, remote SHA-256 digests, explicit prerelease status, and no Linux binary | [`v0.8.5.2-alpha.1`](https://github.com/keith-yan/vibe-service-guardian/releases/tag/v0.8.5.2-alpha.1), `docs/RELEASE-NOTES-0.8.5.2-alpha.1.md` | Available | Maintainer-controlled publication and integrity verification; does not prove an external download, successful installation, real-world use, or independent security review |
 
 ## Rules
 
 - “Available” means the linked artifact exists and its stated validation ran; it does not widen the claim beyond the limitation column.
 - “Partial” means a source exists but supports only the explicitly stated subset of a broader claim.
 - External quotes, usage counts, and case studies require source URL or written consent, collection date, and denominator.
+- GitHub Stars are public attention, not users. Asset download counters can include the maintainer, bots, repeated downloads, and checksum sidecars; record collection time and never convert them to unique users or installations.
 - Never add raw `data/`, SQLite databases, logs, paths, IP addresses, credentials, session IDs, or model responses.
 - If evidence becomes stale or invalid, mark it superseded/invalidated; do not silently delete the history after publication.

--- a/docs/PUBLIC-RELEASE-CHECKLIST.md
+++ b/docs/PUBLIC-RELEASE-CHECKLIST.md
@@ -14,8 +14,8 @@
 - [x] 启用 GitHub Private Vulnerability Reporting，并确认 `SECURITY.md`、`SUPPORT.md` 与维护者清单指向同一私密入口。
 - [x] 复核 `IMPACT.md` 与证据登记表：目标没有写成成就，本机报告没有冒充独立采用，尚无真实案例的项目继续保持“缺失”。
 - [x] 检查公开 Git 历史与当前树；`release/`、`data/`、`.venv/`、`build/`、`dist/` 均不进入版本历史。
-- [ ] 本元数据提交合并后，确认新的最终 `main` CI 全绿并重新构建 6 个计划上传文件；每个文件必须使用精确白名单和同名 SHA-256。包含预构建 Windows EXE 的 ZIP 内含许可证清单与 SPDX SBOM；macOS 源码构建包在目标机生成二进制时生成对应许可证与 SBOM。
-- [ ] 基于新的最终 `main` 再使用 [`GITHUB-RELEASE-0.8.5.2-alpha.1.md`](GITHUB-RELEASE-0.8.5.2-alpha.1.md) 复核标签、目标提交、预发布/Latest 选项和 6 个上传文件；发布后还要回读线上实际结果。
+- [x] 元数据提交合并后，最终 `main@0093355` 的 10 项 CI 全绿并重新构建 6 个计划上传文件；每个文件使用精确白名单和同名 SHA-256。包含预构建 Windows EXE 的 ZIP 内含许可证清单与 SPDX SBOM；macOS 源码构建包在目标机生成二进制时生成对应许可证与 SBOM。
+- [x] 基于最终 `main@0093355` 使用 [`GITHUB-RELEASE-0.8.5.2-alpha.1.md`](GITHUB-RELEASE-0.8.5.2-alpha.1.md) 复核并发布 [`v0.8.5.2-alpha.1`](https://github.com/keith-yan/vibe-service-guardian/releases/tag/v0.8.5.2-alpha.1)：`Prerelease=true`、`Latest=false`、6 个远程资产摘要匹配、Linux 包未上传；已通过匿名公开页面和匿名下载回读。
 
 ## OpenAI Codex for OSS 的官方条件
 
@@ -31,7 +31,7 @@
 
 ## 当前项目的客观缺口
 
-本地代码质量文件不能替代公开维护证据。项目现已建立公开仓库并形成可核验的 PR 合并记录，但在首个 Alpha 准备阶段仍没有可归因的 Release 下载量、持续 Issue/PR 处理周期或独立社区采用证据；这仍是申请竞争力的实质缺口，不能通过填写文案修复。建议完成公开预发布和数轮真实维护后，再以可验证数据说明价值。
+本地代码质量文件不能替代公开维护证据。项目现已建立公开仓库、可核验的 PR 合并记录和一个带校验资产的 Alpha prerelease；截至 2026-08-23 00:43（UTC+8），GitHub API记录资产下载为 0。项目仍没有可归因的外部用户、安装、独立贡献者、持续 Issue/PR 处理周期或独立社区采用证据；这仍是申请竞争力的实质缺口，不能通过填写文案修复。后续只能用带日期、来源和限制的真实维护数据逐步补足。
 
 当前代码已经提供显式、脱敏、按服务指纹去重的本机成效报告，但它只解决“如何以后收集自报结果”，不等于现在已经拥有外部用户证据。至少应再获得经同意的独立案例，并按 `docs/case-studies/README.md` 记录证据等级、测量窗口、分母和限制。
 


### PR DESCRIPTION
## Summary

- record the dated public repository and Alpha release snapshot in `IMPACT.md`
- add public release-integrity evidence and explicit adoption limitations to the evidence register
- close the completed release-readiness checklist items against `main@0093355`

## Evidence boundaries

- 112 GitHub Stars are reported as public attention, not users or installations
- the release and maintainer activity are not presented as independent adoption
- no external user, installation, independent contributor, or case study is claimed
- the application draft remains local and is not included in this pull request

## Validation

- 243 unit tests passed; 1 Windows-inapplicable test skipped
- Ruff passed
- Bandit medium/high-risk scan passed
- 20 hash-locked requirement files verified
- public-tree audit passed with no findings
- Markdown links, evidence contracts, application field lengths, and `git diff --check` passed

## Release boundary

This documentation-only pull request does not modify the published `v0.8.5.2-alpha.1` tag, release body, prerelease/latest settings, or assets.
